### PR TITLE
Add support for dynamic mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 /hardware/
 /output/
+.DS_store

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ select text, for example.
 
 After getting used to the Space Cadet style of typing, you may wish to enable
 this sort of functionality on other keys, as well.  Fortunately, the Space Cadet
-plugin is configurable and extensible to support adding symbols to other keys,
-as well.  Along with `(` on your left `Shift` key and `)` on your right `Shift` key,
-you may wish to add other programming mainstays such as `{` to your left-side `cmd` key,
+plugin is configurable and extensible to support adding symbols to other keys.  
+Along with `(` on your left `Shift` key and `)` on your right `Shift` key,
+you may wish to add other such programming mainstays as `{` to your left-side `cmd` key,
 `}` to your right-side `alt` key,  `[` to your left `Control` key, and `]` to your right 
 `Control` key.  You can map the keys in whatever way you may wish to do, so feel free to 
 experiment with different combinations and discover what works best for you!
@@ -69,17 +69,20 @@ void setup() {
   Kaleidoscope.use(&SpaceCadet);
 
   //Set the keymap with a 250ms timeout per-key
-  static kaleidoscope::ModifierKeyMap spacecadetmap[] = {
+  //Setting is {KeyThatWasPressed, AlternativeKeyToSend, TimeoutInMS}
+  //Note: must end with the SPACECADET_MAP_END delimiter
+  static kaleidoscope::SpaceCadet::KeyBinding spacecadetmap[] = {
     {Key_LeftShift, Key_LeftParen, 250}
-    ,{Key_RightShift, Key_RightParen, 250}
-    ,{Key_LeftGui, Key_LeftCurlyBracket, 250}
-    ,{Key_RightAlt, Key_RightCurlyBracket, 250}
-    ,{Key_LeftAlt, Key_RightCurlyBracket, 250}
-    ,{Key_LeftControl, Key_LeftBracket, 250}
-    ,{Key_RightControl, Key_RightBracket, 250}
+    , {Key_RightShift, Key_RightParen, 250}
+    , {Key_LeftGui, Key_LeftCurlyBracket, 250}
+    , {Key_RightAlt, Key_RightCurlyBracket, 250}
+    , {Key_LeftAlt, Key_RightCurlyBracket, 250}
+    , {Key_LeftControl, Key_LeftBracket, 250}
+    , {Key_RightControl, Key_RightBracket, 250}
+    , SPACECADET_MAP_END
   };
-  //Tell SpaceCadet to use the map  
-  SpaceCadet.setMap(spacecadetmap, sizeof(spacecadetmap)/sizeof(spacecadetmap[0]));
+  //Set the map.
+  SpaceCadet.map = spacecadetmap;
 
   Kaleidoscope.setup();
 }
@@ -90,16 +93,17 @@ void setup() {
 The plugin provides the `SpaceCadet` object, with the following methods and
 properties:
 
-### `.setMap()`
+### `.map`
 
-> Set the key map.  Takes two arguments: the key map and the number of mappings
-> in the map array.  The key map is an array of `kaleidoscope::ModifierKeyMap`
-> objects, and the size is by default set dynamically by the line
-> `sizeof(spacecadetmap)/sizeof(spacecadetmap[0])`
+> Set the key map.  This takes an array of `kaleidoscope::SpaceCadet::KeyBinding`
+> objects with the special `SPACECADET_MAP_END` sentinal to mark the end of the map.
+> Each KeyBinding object takes, in order, the key that was pressed, the key that
+> should be sent instead, and an optional per-key timeout override
 >
-> Defaults to mapping left `shift` to `(` and right `shift` to `)`.
+> If not explicitly set, defaults to mapping left `shift` to `(` and right `shift`
+> to `)`.
 
-### `kaleidoscope::ModifierKeyMap`
+### `kaleidoscope::SpaceCadet::KeyBinding`
 
 > An object consisting of the key that is pressed, the key that should be sent
 > in its place, and the timeout (in milliseconds) until the key press is

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ select text, for example.
 After getting used to the Space Cadet style of typing, you may wish to enable
 this sort of functionality on other keys, as well.  Fortunately, the Space Cadet
 plugin is configurable and extensible to support adding symbols to other keys,
-as well.  Along with `(` on your left `Shift` key, you with to add other such
-programming mainstays as `{` to your `cmd` key and `[` to your left `Control`
-key (and, of course, the matching bookend symbols on the right).  You can do
-whatever you wish to do, so feel free to experiment with different combinations
-and discover what works best for you!
+as well.  Along with `(` on your left `Shift` key and `)` on your right `Shift` key,
+you may wish to add other programming mainstays such as `{` to your left-side `cmd` key,
+`}` to your right-side `alt` key,  `[` to your left `Control` key, and `]` to your right 
+`Control` key.  You can map the keys in whatever way you may wish to do, so feel free to 
+experiment with different combinations and discover what works best for you!
 
  [space-cadet]: https://en.wikipedia.org/wiki/Space-cadet_keyboard
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
  [st:broken]: https://img.shields.io/badge/broken-X-black.svg?style=flat&colorA=e05d44&colorB=494e52
  [st:experimental]: https://img.shields.io/badge/experimental----black.svg?style=flat&colorA=dfb317&colorB=494e52
 
-[Space Cadet][space-cadet] Shift is a way to make it more convenient to input
+[Space Cadet][space-cadet] is a way to make it more convenient to input
 parens - those `(` and `)` things -, symbols that a lot of programming languages
 use frequently. If you are working with Lisp, you are using these all the time.
 
@@ -25,6 +25,15 @@ and it still would act as a `Shift`, without the parens inserted on release:
 this is useful when you want to augment some mouse action with `Shift`, to
 select text, for example.
 
+After getting used to the Space Cadet style of typing, you may wish to enable
+this sort of functionality on other keys, as well.  Fortunately, the Space Cadet
+plugin is configurable and extensible to support adding symbols to other keys,
+as well.  Along with `(` on your left `Shift` key, you with to add other such
+programming mainstays as `{` to your `cmd` key and `[` to your left `Control`
+key (and, of course, the matching bookend symbols on the right).  You can do
+whatever you wish to do, so feel free to experiment with different combinations
+and discover what works best for you!
+
  [space-cadet]: https://en.wikipedia.org/wiki/Space-cadet_keyboard
 
 ## Using the plugin
@@ -37,38 +46,74 @@ enabling the plugin:
 #include <Kaleidoscope-SpaceCadet.h>
 
 void setup() {
-  Kaleidoscope.use(&SpaceCadetShift);
+  Kaleidoscope.use(&SpaceCadet);
 
   Kaleidoscope.setup();
 }
 ```
 
-This assumes a US QWERTY layout on the host computer, and will use the `9` and
-`0` keys for the left and right parens, respectively. To change these keys, use
-the `.opening_paren` and `.closing_paren` properties outlined below.
+This assumes a US QWERTY layout on the host computer, though the plugin sends
+the correct keymap code for each symbol.  Because the mapping is entirely 
+configurable, though, you may switch out keys at your leisure.
 
-## Plugin methods
+If you wish to enable additional modifier keys (or disable the default behavior
+for the shift and parentheses combinations), configuration is as simple as
+passing a new keymap into the SpaceCadet object, as shown below:
 
-The plugin provides the `SpaceCadetShift` object, with the following methods and
+
+```c++
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-SpaceCadet.h>
+
+void setup() {
+  Kaleidoscope.use(&SpaceCadet);
+
+  //Set the keymap
+  static kaleidoscope::ModifierKeyMap spacecadetmap[] = {
+    {Key_LeftShift, Key_LeftParen, 250}
+    ,{Key_RightShift, Key_RightParen, 250}
+    ,{Key_LeftGui,Key_LeftCurlyBracket,250}
+    ,{Key_RightAlt,Key_RightCurlyBracket,250}
+    ,{Key_LeftAlt,Key_RightCurlyBracket,250}
+    ,{Key_LeftControl,Key_LeftBracket,250}
+    ,{Key_RightControl,Key_RightBracket,250}
+  };
+  //Tell SpaceCadet to use the map  
+  SpaceCadet.setMap(spacecadetmap, sizeof(spacecadetmap)/sizeof(spacecadetmap[0]));
+
+  Kaleidoscope.setup();
+}
+```
+
+##   Plugin methods
+
+The plugin provides the `SpaceCadet` object, with the following methods and
 properties:
 
-### `.opening_paren`
+### `.setMap()`
 
-> Set this property to the key that - when shifted - will result in an opening paren.
+> Set the key map.  Takes two arguments: the key map and the number of mappings
+> in the map array.  The key map is an array of `kaleidoscope::ModifierKeyMap`
+> objects, and the size is by default set dynamically by the line
+> `sizeof(spacecadetmap)/sizeof(spacecadetmap[0])`
 >
-> Defaults to `Key_9`.
+> Defaults to mapping left `shift` to `(` and right `shift` to `)`.
 
-### `.closing_paren`
+### `kaleidoscope::ModifierKeyMap`
 
-> Set this property to the key that - when shifted - will result in a closing paren.
->
-> Defaults to `Key_0`.
+> An object consisting of the key that is pressed, the key that should be sent
+> in its place, and the timeout (in milliseconds) until the key press is
+> considered to be a "held" key press.  The third parameter, the timeout, is
+> optional and may be set per-key or left out entirely (or set to `0`) to use 
+> the default timeout value.
 
 ### `.time_out`
 
 > Set this property to the number of milliseconds to wait before considering a
 > held key in isolation as its secondary role. That is, we'd have to hold a
-> `Shift` key this long, by itself, to trigger the `Shift` role in itself.
+> `Shift` key this long, by itself, to trigger the `Shift` role in itself. This
+> timeout setting can be overridden by an individual key in the keymap, but if
+> it is omitted or set to `0` in the key map, the global timeout will be used.
 >
 > Defaults to 1000.
 
@@ -78,3 +123,7 @@ Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
  [plugin:example]: https://github.com/keyboardio/Kaleidoscope-SpaceCadet/blob/master/examples/SpaceCadet/SpaceCadet.ino
+ 
+or 
+
+ [plugin:example]: https://github.com/advisoray/Kaleidoscope-SpaceCadet/blob/master/examples/SpaceCadet/SpaceCadet.ino

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ select text, for example.
 
 After getting used to the Space Cadet style of typing, you may wish to enable
 this sort of functionality on other keys, as well.  Fortunately, the Space Cadet
-plugin is configurable and extensible to support adding symbols to other keys.  
+plugin is configurable and extensible to support adding symbols to other keys.
 Along with `(` on your left `Shift` key and `)` on your right `Shift` key,
 you may wish to add other such programming mainstays as `{` to your left-side `cmd` key,
 `}` to your right-side `alt` key,  `[` to your left `Control` key, and `]` to your right 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ passing a new keymap into the SpaceCadet object, as shown below:
 void setup() {
   Kaleidoscope.use(&SpaceCadet);
 
-  //Set the keymap
+  //Set the keymap with a 250ms timeout per-key
   static kaleidoscope::ModifierKeyMap spacecadetmap[] = {
     {Key_LeftShift, Key_LeftParen, 250}
     ,{Key_RightShift, Key_RightParen, 250}
-    ,{Key_LeftGui,Key_LeftCurlyBracket,250}
-    ,{Key_RightAlt,Key_RightCurlyBracket,250}
-    ,{Key_LeftAlt,Key_RightCurlyBracket,250}
-    ,{Key_LeftControl,Key_LeftBracket,250}
-    ,{Key_RightControl,Key_RightBracket,250}
+    ,{Key_LeftGui, Key_LeftCurlyBracket, 250}
+    ,{Key_RightAlt, Key_RightCurlyBracket, 250}
+    ,{Key_LeftAlt, Key_RightCurlyBracket, 250}
+    ,{Key_LeftControl, Key_LeftBracket, 250}
+    ,{Key_RightControl, Key_RightBracket, 250}
   };
   //Tell SpaceCadet to use the map  
   SpaceCadet.setMap(spacecadetmap, sizeof(spacecadetmap)/sizeof(spacecadetmap[0]));
@@ -123,7 +123,3 @@ Starting from the [example][plugin:example] is the recommended way of getting
 started with the plugin.
 
  [plugin:example]: https://github.com/keyboardio/Kaleidoscope-SpaceCadet/blob/master/examples/SpaceCadet/SpaceCadet.ino
- 
-or 
-
- [plugin:example]: https://github.com/advisoray/Kaleidoscope-SpaceCadet/blob/master/examples/SpaceCadet/SpaceCadet.ino

--- a/examples/SpaceCadet/SpaceCadet.ino
+++ b/examples/SpaceCadet/SpaceCadet.ino
@@ -47,15 +47,15 @@ void setup() {
   //Setting is {KeyThatWasPressed, AlternativeKeyToSend, TimeoutInMS}
   static kaleidoscope::ModifierKeyMap spacecadetmap[] = {
     {Key_LeftShift, Key_LeftParen, 250}
-    ,{Key_RightShift, Key_RightParen, 250}
-    ,{Key_LeftGui, Key_LeftCurlyBracket, 250}
-    ,{Key_RightAlt, Key_RightCurlyBracket, 250}
-    ,{Key_LeftAlt, Key_RightCurlyBracket, 250}
-    ,{Key_LeftControl, Key_LeftBracket, 250}
-    ,{Key_RightControl, Key_RightBracket, 250}
+    , {Key_RightShift, Key_RightParen, 250}
+    , {Key_LeftGui, Key_LeftCurlyBracket, 250}
+    , {Key_RightAlt, Key_RightCurlyBracket, 250}
+    , {Key_LeftAlt, Key_RightCurlyBracket, 250}
+    , {Key_LeftControl, Key_LeftBracket, 250}
+    , {Key_RightControl, Key_RightBracket, 250}
   };
   //Set the map and the number of entries
-  SpaceCadet.setMap(spacecadetmap, sizeof(spacecadetmap)/sizeof(spacecadetmap[0]));
+  SpaceCadet.setMap(spacecadetmap, sizeof(spacecadetmap) / sizeof(spacecadetmap[0]));
 
   Kaleidoscope.setup();
 }

--- a/examples/SpaceCadet/SpaceCadet.ino
+++ b/examples/SpaceCadet/SpaceCadet.ino
@@ -40,7 +40,22 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 };
 
 void setup() {
-  Kaleidoscope.use(&SpaceCadetShift);
+  //Tell Kaleidoscope to use SpaceCadet
+  Kaleidoscope.use(&SpaceCadet;
+
+  //Set the SpaceCadet map
+  //Setting is {KeyThatWasPressed, AlternativeKeyToSend, TimeoutInMS}
+  static kaleidoscope::ModifierKeyMap spacecadetmap[] = {
+    {Key_LeftShift, Key_LeftParen, 250}
+    ,{Key_RightShift, Key_RightParen, 250}
+    ,{Key_LeftGui,Key_LeftCurlyBracket,250}
+    ,{Key_RightAlt,Key_RightCurlyBracket,250}
+    ,{Key_LeftAlt,Key_RightCurlyBracket,250}
+    ,{Key_LeftControl,Key_LeftBracket,250}
+    ,{Key_RightControl,Key_RightBracket,250}
+  };
+  //Set the map and the number of entries
+  SpaceCadet.setMap(spacecadetmap, sizeof(spacecadetmap)/sizeof(spacecadetmap[0]));
 
   Kaleidoscope.setup();
 }

--- a/examples/SpaceCadet/SpaceCadet.ino
+++ b/examples/SpaceCadet/SpaceCadet.ino
@@ -41,18 +41,18 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
 
 void setup() {
   //Tell Kaleidoscope to use SpaceCadet
-  Kaleidoscope.use(&SpaceCadet;
+  Kaleidoscope.use(&SpaceCadet);
 
   //Set the SpaceCadet map
   //Setting is {KeyThatWasPressed, AlternativeKeyToSend, TimeoutInMS}
   static kaleidoscope::ModifierKeyMap spacecadetmap[] = {
     {Key_LeftShift, Key_LeftParen, 250}
     ,{Key_RightShift, Key_RightParen, 250}
-    ,{Key_LeftGui,Key_LeftCurlyBracket,250}
-    ,{Key_RightAlt,Key_RightCurlyBracket,250}
-    ,{Key_LeftAlt,Key_RightCurlyBracket,250}
-    ,{Key_LeftControl,Key_LeftBracket,250}
-    ,{Key_RightControl,Key_RightBracket,250}
+    ,{Key_LeftGui, Key_LeftCurlyBracket, 250}
+    ,{Key_RightAlt, Key_RightCurlyBracket, 250}
+    ,{Key_LeftAlt, Key_RightCurlyBracket, 250}
+    ,{Key_LeftControl, Key_LeftBracket, 250}
+    ,{Key_RightControl, Key_RightBracket, 250}
   };
   //Set the map and the number of entries
   SpaceCadet.setMap(spacecadetmap, sizeof(spacecadetmap)/sizeof(spacecadetmap[0]));

--- a/examples/SpaceCadet/SpaceCadet.ino
+++ b/examples/SpaceCadet/SpaceCadet.ino
@@ -45,7 +45,8 @@ void setup() {
 
   //Set the SpaceCadet map
   //Setting is {KeyThatWasPressed, AlternativeKeyToSend, TimeoutInMS}
-  static kaleidoscope::ModifierKeyMap spacecadetmap[] = {
+  //Note: must end with the SPACECADET_MAP_END delimiter
+  static kaleidoscope::SpaceCadet::KeyBinding spacecadetmap[] = {
     {Key_LeftShift, Key_LeftParen, 250}
     , {Key_RightShift, Key_RightParen, 250}
     , {Key_LeftGui, Key_LeftCurlyBracket, 250}
@@ -53,9 +54,10 @@ void setup() {
     , {Key_LeftAlt, Key_RightCurlyBracket, 250}
     , {Key_LeftControl, Key_LeftBracket, 250}
     , {Key_RightControl, Key_RightBracket, 250}
+    , SPACECADET_MAP_END
   };
-  //Set the map and the number of entries
-  SpaceCadet.setMap(spacecadetmap, sizeof(spacecadetmap) / sizeof(spacecadetmap[0]));
+  //Set the map.
+  SpaceCadet.map = spacecadetmap;
 
   Kaleidoscope.setup();
 }

--- a/src/Kaleidoscope/SpaceCadet.cpp
+++ b/src/Kaleidoscope/SpaceCadet.cpp
@@ -155,7 +155,6 @@ Key SpaceCadet::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key
   // if a key toggled off (and that must be one of the mapped keys at this point),
   // send the alternative key instead (if we were interrupted, we bailed out earlier).
   if (keyToggledOff(key_state)) {
-    Key pressed_key = map_[index].input;
     Key alternate_key = map_[index].output;
 
     //Since we are sending the actual key (no need for shift, etc),

--- a/src/Kaleidoscope/SpaceCadet.cpp
+++ b/src/Kaleidoscope/SpaceCadet.cpp
@@ -41,10 +41,10 @@ KeyBinding * SpaceCadet::map = {
   {Key_LeftShift, Key_LeftParen, 0}
   , {Key_RightShift, Key_RightParen, 0}
   //These may be uncommented, added, or set in the main sketch
-  /*,{Key_LeftGui,Key_LeftCurlyBracket,250}
-  ,{Key_RightAlt,Key_RightCurlyBracket,250}
-  ,{Key_LeftControl,Key_LeftBracket,250}
-  ,{Key_RightControl,Key_RightBracket,250}*/
+  /*,{Key_LeftGui,Key_LeftCurlyBracket, 250}
+  ,{Key_RightAlt,Key_RightCurlyBracket, 250}
+  ,{Key_LeftControl,Key_LeftBracket, 250}
+  ,{Key_RightControl,Key_RightBracket, 250}*/
   , SPACECADET_MAP_END
 };
 uint16_t SpaceCadet::time_out = 1000;

--- a/src/Kaleidoscope/SpaceCadet.cpp
+++ b/src/Kaleidoscope/SpaceCadet.cpp
@@ -21,7 +21,6 @@
 
 namespace kaleidoscope {
 
-
 //Constructor with input and output, and assume default timeout
 SpaceCadet::KeyBinding::KeyBinding(Key input_, Key output_) {
   input = input_;
@@ -36,18 +35,25 @@ SpaceCadet::KeyBinding::KeyBinding(Key input_, Key output_, uint16_t timeout_) {
 }
 
 //Space Cadet
-KeyBinding * SpaceCadet::map = {
-  //By default, respect the default timeout
-  {Key_LeftShift, Key_LeftParen, 0}
-  , {Key_RightShift, Key_RightParen, 0}
-  //These may be uncommented, added, or set in the main sketch
-  /*,{Key_LeftGui,Key_LeftCurlyBracket, 250}
-  ,{Key_RightAlt,Key_RightCurlyBracket, 250}
-  ,{Key_LeftControl,Key_LeftBracket, 250}
-  ,{Key_RightControl,Key_RightBracket, 250}*/
-  , SPACECADET_MAP_END
-};
+SpaceCadet::KeyBinding * SpaceCadet::map;
 uint16_t SpaceCadet::time_out = 1000;
+
+//Empty Constructor
+SpaceCadet::SpaceCadet() {
+  SpaceCadet::KeyBinding initialmap[] = {
+    //By default, respect the default timeout
+    {Key_LeftShift, Key_LeftParen, 0}
+    , {Key_RightShift, Key_RightParen, 0}
+    //These may be uncommented, added, or set in the main sketch
+    /*,{Key_LeftGui,Key_LeftCurlyBracket, 250}
+    ,{Key_RightAlt,Key_RightCurlyBracket, 250}
+    ,{Key_LeftControl,Key_LeftBracket, 250}
+    ,{Key_RightControl,Key_RightBracket, 250}*/
+    , SPACECADET_MAP_END
+  };
+
+  map = initialmap;
+}
 
 void SpaceCadet::begin() {
   Kaleidoscope.useEventHandlerHook(eventHandlerHook);

--- a/src/Kaleidoscope/SpaceCadet.cpp
+++ b/src/Kaleidoscope/SpaceCadet.cpp
@@ -21,158 +21,158 @@
 
 namespace kaleidoscope {
 
-    //Default, empty constructor
-    ModifierKeyMap::ModifierKeyMap(){
+//Default, empty constructor
+ModifierKeyMap::ModifierKeyMap() {
+}
+
+//Constructor with input and output, and assume default timeout
+ModifierKeyMap::ModifierKeyMap(Key input_, Key output_) {
+  input = input_;
+  output = output_;
+}
+
+//Constructor with all three set
+ModifierKeyMap::ModifierKeyMap(Key input_, Key output_, uint16_t timeout_) {
+  input = input_;
+  output = output_;
+  timeout = timeout_;
+}
+
+//Space Cadet
+uint8_t SpaceCadet::map_size_ = 0;
+ModifierKeyMap * SpaceCadet::map_;
+uint16_t SpaceCadet::time_out = 1000;
+
+//Empty constructor
+SpaceCadet::SpaceCadet() {
+  //By default, we make one with left shift sending left paren, and right shift sending right paren
+  static ModifierKeyMap internalMap[] = {
+    //By default, respect the default timeout
+    {Key_LeftShift, Key_LeftParen, 0}
+    , {Key_RightShift, Key_RightParen, 0}
+    //These may be uncommented, added, or set in the main sketch
+    /*,{Key_LeftGui,Key_LeftCurlyBracket,250}
+    ,{Key_RightAlt,Key_RightCurlyBracket,250}
+    ,{Key_LeftControl,Key_LeftBracket,250}
+    ,{Key_RightControl,Key_RightBracket,250}*/
+  };
+
+  //Set the variables to our internal map
+  map_ = internalMap;
+  map_size_ = sizeof(internalMap) / sizeof(internalMap[0]);
+}
+
+//Void function to reset the modifier map if desired.
+void SpaceCadet::setMap(ModifierKeyMap * map, uint8_t map_size) {
+  //Set the map
+  map_ = map;
+  //set the map size to be the length of the array
+  map_size_ = map_size;
+}
+
+void SpaceCadet::begin() {
+  Kaleidoscope.useEventHandlerHook(eventHandlerHook);
+}
+
+Key SpaceCadet::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state) {
+
+  // If nothing happened, bail out fast.
+  if (!keyIsPressed(key_state) && !keyWasPressed(key_state)) {
+    return mapped_key;
+  }
+
+  // If a key has been just toggled on...
+  if (keyToggledOn(key_state)) {
+
+    if (map_size_ > 0) {
+      //This will only set one key, and if it isn't in our map it clears everything
+      //for the non-pressed key
+      for (uint8_t i = 0; i < map_size_; ++i) {
+        if (mapped_key.raw == map_[i].input.raw) {
+          //The keypress was valid and a match.
+          map_[i].flagged = true;
+          map_[i].start_time = millis();
+        } else {
+          //The keypress wasn't a match.
+          map_[i].flagged = false;
+          map_[i].start_time = 0;
+        }
+      }
     }
 
-    //Constructor with input and output, and assume default timeout
-    ModifierKeyMap::ModifierKeyMap(Key input_, Key output_){
-        input = input_;
-        output = output_;
+    // this is all we need to do on keypress, let the next handler do its thing too.
+    return mapped_key;
+  }
+
+  // if the state is empty, that means that either the shifts weren't pressed,
+  // or we used another key in the interim. in both cases, nothing special to do.
+  bool valid_key = false;
+  bool pressed_key_was_valid = false;
+  uint8_t index = 0;
+
+  if (map_size_ > 0) {
+    //Look to see if any keys in our map  are flagged
+    for (uint8_t i = 0; i < map_size_; ++i) {
+
+      if (map_[i].flagged) {
+        valid_key = true;
+        index = i;
+      }
+      if (map_[i].input.raw == mapped_key.raw) {
+        pressed_key_was_valid = true;
+      }
     }
+  }
 
-    //Constructor with all three set
-    ModifierKeyMap::ModifierKeyMap(Key input_, Key output_, uint16_t timeout_) {
-        input = input_;
-        output = output_;
-        timeout = timeout_;
-    }
+  //If no valid mapped keys were pressed, simply return the keycode
+  if (!valid_key) {
+    return mapped_key;
+  }
 
-    //Space Cadet
-    uint8_t SpaceCadet::map_size_ = 0;
-    ModifierKeyMap * SpaceCadet::map_;
-    uint16_t SpaceCadet::time_out = 1000;
+  //use the map index to find the local timeout for this key
+  uint16_t current_timeout = map_[index].timeout;
+  //If that isn't set, use the global timeout setting.
+  if (current_timeout == 0) {
+    current_timeout = time_out;
+  }
 
-    //Empty constructor
-    SpaceCadet::SpaceCadet() {
-        //By default, we make one with left shift sending left paren, and right shift sending right paren
-        static ModifierKeyMap internalMap[] = {
-            //By default, respect the default timeout
-            {Key_LeftShift, Key_LeftParen, 0}
-            ,{Key_RightShift, Key_RightParen, 0}
-            //These may be uncommented, added, or set in the main sketch
-            /*,{Key_LeftGui,Key_LeftCurlyBracket,250}
-            ,{Key_RightAlt,Key_RightCurlyBracket,250}
-            ,{Key_LeftControl,Key_LeftBracket,250}
-            ,{Key_RightControl,Key_RightBracket,250}*/
-        };
+  if ((millis() - map_[index].start_time) >= current_timeout) {
+    // if we timed out, that means we need to keep pressing the mapped
+    // key, but we won't need to send the alternative key in the end
+    map_[index].flagged = false;
+    map_[index].start_time = 0;
+    return mapped_key;
+  }
 
-        //Set the variables to our internal map
-        map_ = internalMap;
-        map_size_ = sizeof(internalMap)/sizeof(internalMap[0]);
-    }
+  // If the key that was pressed isn't one of our mapped keys, just
+  // return. This can happen when another key is released, and that should not
+  // interrupt us.
 
-    //Void function to reset the modifier map if desired.
-    void SpaceCadet::setMap(ModifierKeyMap * map, uint8_t map_size){
-        //Set the map
-        map_ = map;
-        //set the map size to be the length of the array
-        map_size_ = map_size;
-    }
+  if (!pressed_key_was_valid) {
+    return mapped_key;
+  }
 
-    void SpaceCadet::begin() {
-        Kaleidoscope.useEventHandlerHook(eventHandlerHook);
-    }
+  // if a key toggled off (and that must be one of the mapped keys at this point),
+  // send the alternative key instead (if we were interrupted, we bailed out earlier).
+  if (keyToggledOff(key_state)) {
+    Key pressed_key = map_[index].input;
+    Key alternate_key = map_[index].output;
 
-    Key SpaceCadet::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state) {
+    //Since we are sending the actual key (no need for shift, etc),
+    //only need to send that key and not the original key. In fact, we
+    //may want to even UNSET the originally pressed key (future
+    //enhanacement?).  This might also mean we don't need to return the
+    //key that was pressed, though I haven't confirmed that.
+    handleKeyswitchEvent(alternate_key, row, col, IS_PRESSED | INJECTED);
+    hid::sendKeyboardReport();
 
-        // If nothing happened, bail out fast.
-        if (!keyIsPressed(key_state) && !keyWasPressed(key_state)) {
-            return mapped_key;
-        }
+    //Unflag the key so we don't try this again.
+    map_[index].flagged = false;
+    map_[index].start_time = 0;
+  }
 
-        // If a key has been just toggled on...
-        if (keyToggledOn(key_state)) {
-
-            if(map_size_ > 0) {
-                //This will only set one key, and if it isn't in our map it clears everything 
-                //for the non-pressed key
-                for (uint8_t i = 0; i < map_size_; ++i) {
-                    if(mapped_key.raw == map_[i].input.raw) {
-                        //The keypress was valid and a match.
-                        map_[i].flagged = true;
-                        map_[i].start_time = millis();
-                    } else {
-                        //The keypress wasn't a match.
-                        map_[i].flagged = false;
-                        map_[i].start_time = 0;
-                    }
-                }
-            }
-
-            // this is all we need to do on keypress, let the next handler do its thing too.
-            return mapped_key;
-        }
-
-        // if the state is empty, that means that either the shifts weren't pressed,
-        // or we used another key in the interim. in both cases, nothing special to do.
-        bool valid_key = false;
-        bool pressed_key_was_valid = false;
-        uint8_t index = 0;
-        
-        if(map_size_ > 0) {
-            //Look to see if any keys in our map  are flagged
-            for (uint8_t i = 0; i < map_size_; ++i) {
-
-                if (map_[i].flagged) {
-                    valid_key = true;
-                    index = i;
-                }
-                if (map_[i].input.raw == mapped_key.raw) {
-                    pressed_key_was_valid = true;
-                }
-            }
-        }
-
-        //If no valid mapped keys were pressed, simply return the keycode
-        if (!valid_key) {
-            return mapped_key;
-        }
-
-        //use the map index to find the local timeout for this key
-        uint16_t current_timeout = map_[index].timeout;
-        //If that isn't set, use the global timeout setting.
-        if(current_timeout == 0){
-            current_timeout = time_out;
-        }
-
-        if ((millis() - map_[index].start_time) >= current_timeout) {
-            // if we timed out, that means we need to keep pressing the mapped
-            // key, but we won't need to send the alternative key in the end
-            map_[index].flagged = false;
-            map_[index].start_time = 0;
-            return mapped_key;
-        }
-
-        // If the key that was pressed isn't one of our mapped keys, just 
-        // return. This can happen when another key is released, and that should not
-        // interrupt us.
-
-        if (!pressed_key_was_valid) {
-            return mapped_key;
-        }
-
-        // if a key toggled off (and that must be one of the mapped keys at this point),
-        // send the alternative key instead (if we were interrupted, we bailed out earlier).
-        if (keyToggledOff(key_state)) {
-            Key pressed_key = map_[index].input;
-            Key alternate_key = map_[index].output;
-
-            //Since we are sending the actual key (no need for shift, etc),
-            //only need to send that key and not the original key. In fact, we
-            //may want to even UNSET the originally pressed key (future
-            //enhanacement?).  This might also mean we don't need to return the
-            //key that was pressed, though I haven't confirmed that.
-            handleKeyswitchEvent(alternate_key, row, col, IS_PRESSED | INJECTED);
-            hid::sendKeyboardReport();
-
-            //Unflag the key so we don't try this again.
-            map_[index].flagged = false;
-            map_[index].start_time = 0;
-        }
-
-        return mapped_key;
-    }
+  return mapped_key;
+}
 
 }
 

--- a/src/Kaleidoscope/SpaceCadet.cpp
+++ b/src/Kaleidoscope/SpaceCadet.cpp
@@ -14,84 +14,202 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Modified by Ben Gemperline to support additional keys.
  */
 
 #include <Kaleidoscope-SpaceCadet.h>
 #include <kaleidoscope/hid.h>
+#include <stdint.h>
+#include "SpaceCadet.h"
 
 namespace kaleidoscope {
 
-uint8_t SpaceCadetShift::paren_needed_;
-uint32_t SpaceCadetShift::start_time_;
-uint16_t SpaceCadetShift::time_out = 1000;
-Key SpaceCadetShift::opening_paren = Key_9, SpaceCadetShift::closing_paren = Key_0;
-
-SpaceCadetShift::SpaceCadetShift() {
-}
-
-void SpaceCadetShift::begin() {
-  Kaleidoscope.useEventHandlerHook(eventHandlerHook);
-}
-
-Key SpaceCadetShift::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state) {
-  // If nothing happened, bail out fast.
-  if (!keyIsPressed(key_state) && !keyWasPressed(key_state)) {
-    return mapped_key;
-  }
-
-  // If a key has been just toggled on...
-  if (keyToggledOn(key_state)) {
-    if (mapped_key.raw == Key_LeftShift.raw) {  // if it is LShift, remember it
-      bitWrite(paren_needed_, 0, 1);
-      start_time_ = millis();
-    } else if (mapped_key.raw == Key_RightShift.raw) {  // if it is RShift, remember it
-      bitWrite(paren_needed_, 1, 1);
-      start_time_ = millis();
-    } else {  // if it is something else, we do not need a paren at the end.
-      paren_needed_ = 0;
-      start_time_ = 0;
+    //Default constructor
+    ModifierKeyMap::ModifierKeyMap(){
     }
 
-    // this is all we need to do on keypress, let the next handler do its thing too.
-    return mapped_key;
-  }
+    //Constructor with input and output, and assume default timeout
+    ModifierKeyMap::ModifierKeyMap(Key input_, Key output_){
+        input = input_;
+        output = output_;
+    }
 
-  // if the state is empty, that means that either the shifts weren't pressed,
-  // or we used another key in the interim. in both cases, nothing special to do.
-  if (!paren_needed_)
-    return mapped_key;
+    //Constructor with all three set
+    ModifierKeyMap::ModifierKeyMap(Key input_, Key output_, uint16_t timeout_) {
+        input = input_;
+        output = output_;
+        timeout = timeout_;
+    }
 
-  // if we timed out, that means we need to keep pressing shift, but won't
-  // need the parens in the end.
-  if ((millis() - start_time_) >= time_out) {
-    paren_needed_ = 0;
-    return mapped_key;
-  }
+    //Space Cadet
+    uint8_t SpaceCadet::map_size = 0;
+    ModifierKeyMap * SpaceCadet::map;
+    uint16_t SpaceCadet::time_out = 1000;
 
-  // if we have a state, but the key in question is not either of the shifts,
-  // return. This can happen when another key is released, and that should not
-  // interrupt us.
-  if (mapped_key.raw != Key_LeftShift.raw &&
-      mapped_key.raw != Key_RightShift.raw)
-    return mapped_key;
+    SpaceCadet::SpaceCadet() {
+        //By default, we make one with left shift sending left paren, and right shift sending right paren
+        static ModifierKeyMap internalMap[] = {
+            {Key_LeftShift,Key_LeftParen,250}
+            ,{Key_RightShift,Key_RightParen,250}
+            /*,{Key_LeftGui,Key_LeftCurlyBracket,250}
+            ,{Key_RightAlt,Key_RightCurlyBracket,250}
+            ,{Key_LeftControl,Key_LeftBracket,250}
+            ,{Key_RightControl,Key_RightBracket,250}*/
+        };
 
-  // if a key toggled off (and that must be one of the shifts at this point),
-  // send the parens too (if we were interrupted, we bailed out earlier).
-  if (keyToggledOff(key_state)) {
-    Key paren = opening_paren;
-    if (bitRead(paren_needed_, 1))
-      paren = closing_paren;
+        map = internalMap;
+        map_size = sizeof(internalMap)/sizeof(internalMap[0]);
+        //setMap(internalMap, sizeof(internalMap));
+    }
 
-    handleKeyswitchEvent(mapped_key, row, col, IS_PRESSED | INJECTED);
-    handleKeyswitchEvent(paren, row, col, IS_PRESSED | INJECTED);
-    hid::sendKeyboardReport();
+    SpaceCadet::SpaceCadet(ModifierKeyMap * map_, uint8_t map_size_) {
+        //Call the initializer
+        setMap(map_, map_size_);
+    }
 
-    paren_needed_ = 0;
-  }
+    void SpaceCadet::setMap(ModifierKeyMap * map_, uint8_t map_size_){
+        //Set the map
+        map = map_;
+        //set the map size to be the length of the array
+        map_size = map_size_;
+    }
 
-  return mapped_key;
+    void SpaceCadet::begin() {
+        Kaleidoscope.useEventHandlerHook(eventHandlerHook);
+    }
+
+    Key SpaceCadet::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state) {
+        //char buffer[50];
+
+        //Serial.print("In eventHandlerHook");
+        // If nothing happened, bail out fast.
+        if (!keyIsPressed(key_state) && !keyWasPressed(key_state)) {
+            return mapped_key;
+        }
+
+        // If a key has been just toggled on...
+        if (keyToggledOn(key_state)) {
+
+            /*
+            sprintf(buffer, "Pressed Key: %u\n", mapped_key.raw );
+            Serial.print(buffer);
+            */
+
+            if(map_size > 0) {
+                //This will only set one key, and if it isn't in our map it clears everything for the non-pressed key
+                for (uint8_t i = 0; i < map_size; ++i) {
+                    if(mapped_key.raw == map[i].input.raw) {
+                        map[i].flagged = true;
+                        map[i].start_time = millis();
+                        //There was a valid keypress
+                        /*sprintf(buffer, "Valid Key: %u\n", mapped_key.raw);
+                        Serial.print(buffer);*/
+
+                    } else {
+                        map[i].flagged = false;
+                        map[i].start_time = 0;
+                    }
+
+                    /*
+                    sprintf(buffer, "Key: %u\n", map[i].input.raw);
+                    Serial.print(buffer);
+                    if(map[i].flagged){
+                        Serial.print("Flagged\n");
+                    } else {
+                        Serial.print("Not Flagged\n");
+                    }
+                    sprintf(buffer, "Start Time: %u\n", map[i].start_time);
+                    Serial.print(buffer);
+                     */
+                }
+            }
+
+            // this is all we need to do on keypress, let the next handler do its thing too.
+            return mapped_key;
+        }
+
+        // if the state is empty, that means that either the shifts weren't pressed,
+        // or we used another key in the interim. in both cases, nothing special to do.
+        bool valid_key = false;
+        bool pressed_key_was_valid = false;
+        uint8_t index = 0;
+        if(map_size > 0) {
+            //Look to see if any are flagged
+            for (uint8_t i = 0; i < map_size; ++i) {
+
+                if (map[i].flagged) {
+                    valid_key = true;
+                    index = i;
+                }
+                if (map[i].input.raw == mapped_key.raw) {
+                    pressed_key_was_valid = true;
+                }
+            }
+        }
+        if (!valid_key) {
+            return mapped_key;
+        }
+
+        //use the map index to find the local timeout for this key
+        uint16_t current_timeout = map[index].timeout;
+        //If that isn't set, use the global timeout setting.
+        if(current_timeout == 0){
+            current_timeout = time_out;
+        }
+
+
+
+        if ((millis() - map[index].start_time) >= current_timeout) {
+            // if we timed out, that means we need to keep pressing shift, but won't
+            // need the parens in the end.
+            map[index].flagged = false;
+            map[index].start_time = 0;
+            return mapped_key;
+        }
+
+        /*
+        sprintf(buffer, "Check Index: %u\n", index );
+        Serial.print(buffer);
+
+        sprintf(buffer, "Current Timeout: %u\n", current_timeout );
+        Serial.print(buffer);
+
+        sprintf(buffer, "Start Time: %u\n", map[index].start_time );
+        Serial.print(buffer);
+
+        Serial.print("Made it past timeout check\n");
+        */
+
+        // if we have a state, but the key in question is not either of the shifts,
+        // return. This can happen when another key is released, and that should not
+        // interrupt us.
+
+        if (!pressed_key_was_valid) {
+            return mapped_key;
+        }
+
+        //Serial.print("Made it validity check\n");
+
+
+        // if a key toggled off (and that must be one of the shifts at this point),
+        // send the parens too (if we were interrupted, we bailed out earlier).
+        if (keyToggledOff(key_state)) {
+            Key pressed_key = map[index].input;
+            Key alternate_key = map[index].output;
+
+            //Don't necessarily need to send the original key
+            //handleKeyswitchEvent(pressed_key, row, col, WAS_PRESSED | INJECTED);
+            handleKeyswitchEvent(alternate_key, row, col, IS_PRESSED | INJECTED);
+            hid::sendKeyboardReport();
+
+            map[index].flagged = false;
+            map[index].start_time = 0;
+        }
+
+        return mapped_key;
+    }
+
 }
 
-}
-
-kaleidoscope::SpaceCadetShift SpaceCadetShift;
+kaleidoscope::SpaceCadet SpaceCadet;

--- a/src/Kaleidoscope/SpaceCadet.cpp
+++ b/src/Kaleidoscope/SpaceCadet.cpp
@@ -68,18 +68,19 @@ Key SpaceCadet::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key
 
   // If a key has been just toggled on...
   if (keyToggledOn(key_state)) {
-    
+
     //This will only set one key, and if it isn't in our map it clears everything
     //for the non-pressed key
-    for (uint8_t i = 0 ;; ++i) {
-      //Check for ending sentinal and exit
-      if(
+    //Exit condition is if we reach the sentinal
+    for (
+      uint8_t i = 0 ;
+      !(
         map[i].input.raw == Key_NoKey.raw
         && map[i].output.raw == Key_NoKey.raw
         && map[i].timeout == 0
-      ) {
-        break;
-      }
+      ) ;
+      ++i
+    ) {
 
       if (mapped_key.raw == map[i].input.raw) {
         //The keypress was valid and a match.
@@ -102,17 +103,17 @@ Key SpaceCadet::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key
   bool pressed_key_was_valid = false;
   uint8_t index = 0;
 
-  //Look to see if any keys in our map  are flagged
-  for (uint8_t i = 0 ;; ++i) {
-
-    //Check for ending sentinal and exit
-    if(
+  //Look to see if any keys in our map  are flagged.
+  //Exit condition is if we reach the sentinal
+  for (
+    uint8_t i = 0 ;
+    !(
       map[i].input.raw == Key_NoKey.raw
       && map[i].output.raw == Key_NoKey.raw
       && map[i].timeout == 0
-    ) {
-      break;
-    }
+    ) ;
+    ++i
+  ) {
 
     if (map[i].flagged) {
       valid_key = true;

--- a/src/Kaleidoscope/SpaceCadet.h
+++ b/src/Kaleidoscope/SpaceCadet.h
@@ -1,6 +1,6 @@
 /* -*- mode: c++ -*-
- * Kaleidoscope-SpaceCadet -- Space Cadet Shift
- * Copyright (C) 2016, 2017  Gergely Nagy
+ * Kaleidoscope-SpaceCadet -- Space Cadet Shift Extended
+ * Copyright (C) 2016, 2017  Gergely Nagy, Ben Gemperline
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,9 +48,6 @@ namespace kaleidoscope {
             //Empty constructor
             SpaceCadet(void);
 
-            //Constructor with mapping
-            SpaceCadet(ModifierKeyMap * map, uint8_t map_size);
-
             //Methods
             void setMap(ModifierKeyMap * map, uint8_t map_size);
             void begin(void) final;
@@ -58,8 +55,8 @@ namespace kaleidoscope {
             static uint16_t time_out;
 
         private:
-            static uint8_t map_size;
-            static ModifierKeyMap * map;
+            static uint8_t map_size_;
+            static ModifierKeyMap * map_;
             static Key eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state);
     };
 };

--- a/src/Kaleidoscope/SpaceCadet.h
+++ b/src/Kaleidoscope/SpaceCadet.h
@@ -21,44 +21,44 @@
 #include <Kaleidoscope.h>
 
 namespace kaleidoscope {
-    //Declarations for the modifier key mapping
-    class ModifierKeyMap {
-        public:
-            //Empty constructor; set the vars separately
-            ModifierKeyMap(void);
-            //Constructor with input and output
-            ModifierKeyMap(Key input_, Key output_);
-             //Constructor with all three set
-            ModifierKeyMap(Key input_, Key output_, uint16_t timeout_);
-            //The key that is pressed
-            Key input;
-            //the key that is sent
-            Key output;
-            //The timeout (default to global timeout)
-            uint16_t timeout = 0;
-            //The flag (set to 0)
-            bool flagged = false;
-            //the start time for this key press
-            uint32_t start_time = 0;
-    };
+//Declarations for the modifier key mapping
+class ModifierKeyMap {
+ public:
+  //Empty constructor; set the vars separately
+  ModifierKeyMap(void);
+  //Constructor with input and output
+  ModifierKeyMap(Key input_, Key output_);
+  //Constructor with all three set
+  ModifierKeyMap(Key input_, Key output_, uint16_t timeout_);
+  //The key that is pressed
+  Key input;
+  //the key that is sent
+  Key output;
+  //The timeout (default to global timeout)
+  uint16_t timeout = 0;
+  //The flag (set to 0)
+  bool flagged = false;
+  //the start time for this key press
+  uint32_t start_time = 0;
+};
 
-    //Declaration for the method (implementing KaleidoscopePlugin)
-    class SpaceCadet : public KaleidoscopePlugin {
-        public:
-            //Empty constructor
-            SpaceCadet(void);
+//Declaration for the method (implementing KaleidoscopePlugin)
+class SpaceCadet : public KaleidoscopePlugin {
+ public:
+  //Empty constructor
+  SpaceCadet(void);
 
-            //Methods
-            void setMap(ModifierKeyMap * map, uint8_t map_size);
-            void begin(void) final;
+  //Methods
+  void setMap(ModifierKeyMap * map, uint8_t map_size);
+  void begin(void) final;
 
-            static uint16_t time_out;
+  static uint16_t time_out;
 
-        private:
-            static uint8_t map_size_;
-            static ModifierKeyMap * map_;
-            static Key eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state);
-    };
+ private:
+  static uint8_t map_size_;
+  static ModifierKeyMap * map_;
+  static Key eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state);
+};
 };
 
 extern kaleidoscope::SpaceCadet SpaceCadet;

--- a/src/Kaleidoscope/SpaceCadet.h
+++ b/src/Kaleidoscope/SpaceCadet.h
@@ -20,43 +20,45 @@
 
 #include <Kaleidoscope.h>
 
-namespace kaleidoscope {
-//Declarations for the modifier key mapping
-class ModifierKeyMap {
- public:
-  //Empty constructor; set the vars separately
-  ModifierKeyMap(void);
-  //Constructor with input and output
-  ModifierKeyMap(Key input_, Key output_);
-  //Constructor with all three set
-  ModifierKeyMap(Key input_, Key output_, uint16_t timeout_);
-  //The key that is pressed
-  Key input;
-  //the key that is sent
-  Key output;
-  //The timeout (default to global timeout)
-  uint16_t timeout = 0;
-  //The flag (set to 0)
-  bool flagged = false;
-  //the start time for this key press
-  uint32_t start_time = 0;
-};
+#ifndef SPACECADET_MAP_END
+#define SPACECADET_MAP_END {Key_NoKey, Key_NoKey, 0}
+#endif
 
+namespace kaleidoscope {
 //Declaration for the method (implementing KaleidoscopePlugin)
 class SpaceCadet : public KaleidoscopePlugin {
  public:
   //Empty constructor
-  SpaceCadet(void);
+  SpaceCadet(void) {}
 
   //Methods
-  void setMap(ModifierKeyMap * map, uint8_t map_size);
   void begin(void) final;
 
-  static uint16_t time_out;
-
+  //Publically accessible variables
+  static uint16_t time_out;  //  The global timeout in milliseconds
+  static KeyBinding * map;  // The map of key bindings
+  
+  //Declarations for the modifier key mapping
+  class KeyBinding {
+   public:
+    //Empty constructor; set the vars separately
+    KeyBinding(void) {}
+    //Constructor with input and output
+    KeyBinding(Key input_, Key output_);
+    //Constructor with all three set
+    KeyBinding(Key input_, Key output_, uint16_t timeout_);
+    //The key that is pressed
+    Key input;
+    //the key that is sent
+    Key output;
+    //The timeout (default to global timeout)
+    uint16_t timeout = 0;
+    //The flag (set to 0)
+    bool flagged = false;
+    //the start time for this key press
+    uint32_t start_time = 0;
+  };
  private:
-  static uint8_t map_size_;
-  static ModifierKeyMap * map_;
   static Key eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state);
 };
 };

--- a/src/Kaleidoscope/SpaceCadet.h
+++ b/src/Kaleidoscope/SpaceCadet.h
@@ -29,7 +29,7 @@ namespace kaleidoscope {
 class SpaceCadet : public KaleidoscopePlugin {
  public:
   //Internal Class
-    //Declarations for the modifier key mapping
+  //Declarations for the modifier key mapping
   class KeyBinding {
    public:
     //Empty constructor; set the vars separately
@@ -58,7 +58,7 @@ class SpaceCadet : public KaleidoscopePlugin {
 
   //Publically accessible variables
   static uint16_t time_out;  //  The global timeout in milliseconds
-  static SpaceCadet::KeyBinding * map;  // The map of key bindings 
+  static SpaceCadet::KeyBinding * map;  // The map of key bindings
 
  private:
   static Key eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state);

--- a/src/Kaleidoscope/SpaceCadet.h
+++ b/src/Kaleidoscope/SpaceCadet.h
@@ -21,22 +21,47 @@
 #include <Kaleidoscope.h>
 
 namespace kaleidoscope {
+    //Declarations for the modifier key mapping
+    class ModifierKeyMap {
+        public:
+            //Empty constructor; set the vars separately
+            ModifierKeyMap(void);
+            //Constructor with input and output
+            ModifierKeyMap(Key input_, Key output_);
+             //Constructor with all three set
+            ModifierKeyMap(Key input_, Key output_, uint16_t timeout_);
+            //The key that is pressed
+            Key input;
+            //the key that is sent
+            Key output;
+            //The timeout (default to global timeout)
+            uint16_t timeout = 0;
+            //The flag (set to 0)
+            bool flagged = false;
+            //the start time for this key press
+            uint32_t start_time = 0;
+    };
 
-class SpaceCadetShift : public KaleidoscopePlugin {
- public:
-  SpaceCadetShift(void);
+    //Declaration for the method (implementing KaleidoscopePlugin)
+    class SpaceCadet : public KaleidoscopePlugin {
+        public:
+            //Empty constructor
+            SpaceCadet(void);
 
-  void begin(void) final;
+            //Constructor with mapping
+            SpaceCadet(ModifierKeyMap * map, uint8_t map_size);
 
-  static uint16_t time_out;
-  static Key opening_paren, closing_paren;
+            //Methods
+            void setMap(ModifierKeyMap * map, uint8_t map_size);
+            void begin(void) final;
 
- private:
-  static uint8_t paren_needed_;
-  static uint32_t start_time_;
+            static uint16_t time_out;
 
-  static Key eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state);
+        private:
+            static uint8_t map_size;
+            static ModifierKeyMap * map;
+            static Key eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state);
+    };
 };
-};
 
-extern kaleidoscope::SpaceCadetShift SpaceCadetShift;
+extern kaleidoscope::SpaceCadet SpaceCadet;

--- a/src/Kaleidoscope/SpaceCadet.h
+++ b/src/Kaleidoscope/SpaceCadet.h
@@ -21,24 +21,15 @@
 #include <Kaleidoscope.h>
 
 #ifndef SPACECADET_MAP_END
-#define SPACECADET_MAP_END {Key_NoKey, Key_NoKey, 0}
+#define SPACECADET_MAP_END (kaleidoscope::SpaceCadet::KeyBinding) { Key_NoKey, Key_NoKey, 0 }
 #endif
 
 namespace kaleidoscope {
 //Declaration for the method (implementing KaleidoscopePlugin)
 class SpaceCadet : public KaleidoscopePlugin {
  public:
-  //Empty constructor
-  SpaceCadet(void) {}
-
-  //Methods
-  void begin(void) final;
-
-  //Publically accessible variables
-  static uint16_t time_out;  //  The global timeout in milliseconds
-  static KeyBinding * map;  // The map of key bindings
-  
-  //Declarations for the modifier key mapping
+  //Internal Class
+    //Declarations for the modifier key mapping
   class KeyBinding {
    public:
     //Empty constructor; set the vars separately
@@ -58,6 +49,17 @@ class SpaceCadet : public KaleidoscopePlugin {
     //the start time for this key press
     uint32_t start_time = 0;
   };
+
+  //Empty constructor
+  SpaceCadet(void);
+
+  //Methods
+  void begin(void) final;
+
+  //Publically accessible variables
+  static uint16_t time_out;  //  The global timeout in milliseconds
+  static SpaceCadet::KeyBinding * map;  // The map of key bindings 
+
  private:
   static Key eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state);
 };


### PR DESCRIPTION
Hey,

Here's the code that makes SpaceCadet able to support dynamic key maps.  I figured since it was no longer limited to shift, we could kick the 'Shift' part of the name, especially considering that the new name already matches the repo name.

I updated the example and the readme, too.  Please let me know if you need anything to be changed, or if there are any stylistic or implementation details you'd like me to address.

Thanks,
Ben