### PR TITLE
Fix for failing keyboard initialization if map not explicitly set.

### DIFF
--- a/src/Kaleidoscope/SpaceCadet.cpp
+++ b/src/Kaleidoscope/SpaceCadet.cpp
@@ -40,7 +40,7 @@ uint16_t SpaceCadet::time_out = 1000;
 
 //Empty Constructor
 SpaceCadet::SpaceCadet() {
-  SpaceCadet::KeyBinding initialmap[] = {
+  static SpaceCadet::KeyBinding initialmap[] = {
     //By default, respect the default timeout
     {Key_LeftShift, Key_LeftParen, 0}
     , {Key_RightShift, Key_RightParen, 0}


### PR DESCRIPTION
Resolves issue: https://github.com/keyboardio/Kaleidoscope-SpaceCadet/issues/5

https://community.keyboard.io/t/lock-up-when-enabling-space-cadet/531