### PR TITLE
Eliminate unnecessary `sendKeyboardReport`

### DIFF
--- a/src/Kaleidoscope/SpaceCadet.cpp
+++ b/src/Kaleidoscope/SpaceCadet.cpp
@@ -163,8 +163,8 @@ Key SpaceCadet::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key
     //may want to even UNSET the originally pressed key (future
     //enhanacement?).  This might also mean we don't need to return the
     //key that was pressed, though I haven't confirmed that.
+    handleKeyswitchEvent(mapped_key, row, col, INJECTED);
     handleKeyswitchEvent(alternate_key, row, col, IS_PRESSED | INJECTED);
-    hid::sendKeyboardReport();
 
     //Unflag the key so we don't try this again.
     map[index].flagged = false;


### PR DESCRIPTION
It seems that if we inject the release of the mapped modifier key before injecting the press of the alternate key, we avoid the need to call `hid::sendKeyboardReport`, which in turn fixes #7. Which is nice.

Closes #7