### PR TITLE
Extended functionality + fix Alt key under Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 # This stub makefile for a Kaleidoscope plugin pulls in 
 # all targets from the Kaleidoscope-Plugin library
 
-MAKEFILE_PREFIX=keyboardio/avr/libraries/Kaleidoscope-Plugin/build
 UNAME_S := $(shell uname -s)
 
 ifeq ($(UNAME_S),Darwin)
-BOARD_HARDWARE_PATH ?= $(HOME)/Documents/Arduino/hardware
+SKETCHBOOK_DIR ?= $(HOME)/Documents/Arduino/
 else
-BOARD_HARDWARE_PATH ?= $(HOME)/Arduino/hardware
+SKETCHBOOK_DIR ?= $(HOME)/Arduino
 endif
 
-include $(BOARD_HARDWARE_PATH)/$(MAKEFILE_PREFIX)/rules.mk
+BOARD_HARDWARE_PATH ?= $(SKETCHBOOK_DIR)/hardware
+KALEIDOSCOPE_PLUGIN_MAKEFILE_DIR ?= keyboardio/avr/build-tools/makefiles/
+include $(BOARD_HARDWARE_PATH)/$(KALEIDOSCOPE_PLUGIN_MAKEFILE_DIR)/rules.mk

--- a/README.md
+++ b/README.md
@@ -121,6 +121,38 @@ properties:
 >
 > Defaults to 1000.
 
+### `.enable()`
+
+> This method enables the SpaceCadet plugin.  This is useful for interfacing
+> with other plugins or macros, especially where SpaceCadet functionality isn't
+> always desired.  
+>
+> The default behavior is `enabled`.
+
+### `.disable()`
+
+> This method disables the SpaceCadet behavior. This is useful for interfacing
+> with other plugins or macros, especially where SpaceCadet functionality isn't
+> always desired.  
+
+### `.active()`
+
+> This method returns `true` if SpaceCadet is enabled and `false` if SpaceCadet
+> is disabled. This is useful for interfacing with other plugins or macros, 
+> especially where SpaceCadet functionality isn't always desired.
+
+### `Key_SpaceCadetEnable`
+
+> This provides a key for placing on a keymap for enabling the SpaceCadet
+> behavior.  This is only triggered on initial downpress, and does not
+> trigger again if held down or when the key is released.
+
+### `Key_SpaceCadetDisable`
+
+> This provides a key for placing on a keymap for disabling the SpaceCadet
+> behavior. This is only triggered on initial downpress, and does not
+> trigger again if held down or when the key is released.
+
 ## Further reading
 
 Starting from the [example][plugin:example] is the recommended way of getting

--- a/examples/SpaceCadet/SpaceCadet.ino
+++ b/examples/SpaceCadet/SpaceCadet.ino
@@ -22,7 +22,7 @@
 const Key keymaps[][ROWS][COLS] PROGMEM = {
   [0] = KEYMAP_STACKED
   (
-    Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
+    Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_SpaceCadetEnable,
     Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
     Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
     Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
@@ -30,7 +30,7 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
     Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
     Key_skip,
 
-    Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+    Key_SpaceCadetDisable,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
     Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
     Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
     Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,

--- a/src/Kaleidoscope/SpaceCadet.cpp
+++ b/src/Kaleidoscope/SpaceCadet.cpp
@@ -163,8 +163,8 @@ Key SpaceCadet::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key
     //may want to even UNSET the originally pressed key (future
     //enhanacement?).  This might also mean we don't need to return the
     //key that was pressed, though I haven't confirmed that.
+    handleKeyswitchEvent(mapped_key, row, col, INJECTED);
     handleKeyswitchEvent(alternate_key, row, col, IS_PRESSED | INJECTED);
-    hid::sendKeyboardReport();
 
     //Unflag the key so we don't try this again.
     map[index].flagged = false;

--- a/src/Kaleidoscope/SpaceCadet.cpp
+++ b/src/Kaleidoscope/SpaceCadet.cpp
@@ -163,7 +163,6 @@ Key SpaceCadet::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key
     //may want to even UNSET the originally pressed key (future
     //enhanacement?).  This might also mean we don't need to return the
     //key that was pressed, though I haven't confirmed that.
-    handleKeyswitchEvent(mapped_key, row, col, INJECTED);
     handleKeyswitchEvent(alternate_key, row, col, IS_PRESSED | INJECTED);
 
     //Unflag the key so we don't try this again.

--- a/src/Kaleidoscope/SpaceCadet.cpp
+++ b/src/Kaleidoscope/SpaceCadet.cpp
@@ -163,6 +163,7 @@ Key SpaceCadet::eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key
     //may want to even UNSET the originally pressed key (future
     //enhanacement?).  This might also mean we don't need to return the
     //key that was pressed, though I haven't confirmed that.
+    handleKeyswitchEvent(mapped_key, row, col, INJECTED);
     handleKeyswitchEvent(alternate_key, row, col, IS_PRESSED | INJECTED);
 
     //Unflag the key so we don't try this again.

--- a/src/Kaleidoscope/SpaceCadet.h
+++ b/src/Kaleidoscope/SpaceCadet.h
@@ -24,6 +24,12 @@
 #define SPACECADET_MAP_END (kaleidoscope::SpaceCadet::KeyBinding) { Key_NoKey, Key_NoKey, 0 }
 #endif
 
+#ifndef SPACECADET_TOGGLE
+#define SPACECADET_TOGGLE B00000011  // Synthetic, internal
+#define Key_SpaceCadetEnable (Key) { 0,  KEY_FLAGS | SYNTHETIC | IS_INTERNAL | SPACECADET_TOGGLE }
+#define Key_SpaceCadetDisable (Key) { 1,  KEY_FLAGS | SYNTHETIC | IS_INTERNAL | SPACECADET_TOGGLE }
+#endif
+
 namespace kaleidoscope {
 //Declaration for the method (implementing KaleidoscopePlugin)
 class SpaceCadet : public KaleidoscopePlugin {
@@ -55,6 +61,9 @@ class SpaceCadet : public KaleidoscopePlugin {
 
   //Methods
   void begin(void) final;
+  static void enable(void);
+  static void disable(void);
+  static bool active(void);
 
   //Publically accessible variables
   static uint16_t time_out;  //  The global timeout in milliseconds
@@ -62,6 +71,7 @@ class SpaceCadet : public KaleidoscopePlugin {
 
  private:
   static Key eventHandlerHook(Key mapped_key, byte row, byte col, uint8_t key_state);
+  static bool disabled;
 };
 };
 


### PR DESCRIPTION
I made a bunch of changes to improve SpaceCadet for the better.

1. I resolved issue #9 ( https://github.com/keyboardio/Kaleidoscope-SpaceCadet/issues/9 ) to support mappings on Alt keys under Windows.  This change in behavior means that we don't send the initial key value (the key with a mapping) until we hit the timeout (if held) or if we hit another key in combination in the mean time (to keep modifiers working as expected in combination with other keys).  This means that when you place a mapping on Alt, we don't send Alt if you are just tapping -- we only send the other key value.  This prevents Alt capturing the menu bar in Windows apps, and probably means we can better support SpaceCadet on non-modifier keys.

2. I added support for enabling, disabling, and determining if SpaceCadet is currently enabled.  This allows other plugins and macros to better interact with SpaceCadet, and allows us to temporarily disable the behavior if that's desired.

3. I added two new virtual Key entries for placing on the user's keymap.  One key disables SpaceCadet, and the other key enables SpaceCadet.

I also updated the README.md with all of the relevant changes.